### PR TITLE
Fix bug leading to AES-generation and /automation request fails

### DIFF
--- a/server/src/main/java/keywhiz/commands/GenerateAesKeyCommand.java
+++ b/server/src/main/java/keywhiz/commands/GenerateAesKeyCommand.java
@@ -68,7 +68,7 @@ public class GenerateAesKeyCommand extends Command {
 
   @Override public void run(Bootstrap<?> bootstrap, Namespace namespace) throws Exception {
     char[] password = namespace.getString("storepass").toCharArray();
-    Path destination = Paths.get(namespace.get("keystore"));
+    Path destination = Paths.get(namespace.getString("keystore"));
     int keySize = namespace.getInt("keysize");
     String alias = namespace.getString("alias");
 

--- a/server/src/main/resources/keywhiz-development.yaml
+++ b/server/src/main/resources/keywhiz-development.yaml
@@ -112,3 +112,14 @@ contentKeyStore:
 rowHmacCheck: logging
 
 flywaySchemaTable: schema_version
+
+clientAuthConfig:
+  xfcc:
+    - port: 4446
+      allowedClientNames: ["client"]
+      allowedSpiffeIds: []
+  type:
+    useCommonName: true
+    useSpiffeId: false
+  createMissingClients: true
+


### PR DESCRIPTION
The keystore parameter should be a String rather than an URI.